### PR TITLE
Add subtree filtering util

### DIFF
--- a/lib/cju.ts
+++ b/lib/cju.ts
@@ -5,6 +5,8 @@ import type {
   SourcePort,
 } from "circuit-json"
 import * as Soup from "circuit-json"
+import type { SubtreeOptions } from "./subtree"
+import { buildSubtree } from "./subtree"
 
 export type CircuitJsonOps<
   K extends AnyCircuitElement["type"],
@@ -95,6 +97,11 @@ export const cju: GetCircuitJsonUtilFn = ((
         }
         if (prop === "editCount") {
           return internalStore.editCount
+        }
+
+        if (prop === "subtree") {
+          return (opts: SubtreeOptions) =>
+            cju(buildSubtree(circuitJson, opts), options)
         }
 
         const component_type = prop

--- a/lib/subtree.ts
+++ b/lib/subtree.ts
@@ -1,0 +1,92 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export type SubtreeOptions = {
+  subcircuit_id?: string
+  source_group_id?: string
+}
+
+function connect(
+  map: Map<AnyCircuitElement, Set<AnyCircuitElement>>,
+  a: AnyCircuitElement | undefined,
+  b: AnyCircuitElement | undefined,
+) {
+  if (!a || !b) return
+  let setA = map.get(a)
+  if (!setA) {
+    setA = new Set()
+    map.set(a, setA)
+  }
+  setA.add(b)
+  let setB = map.get(b)
+  if (!setB) {
+    setB = new Set()
+    map.set(b, setB)
+  }
+  setB.add(a)
+}
+
+export function buildSubtree(
+  soup: AnyCircuitElement[],
+  opts: SubtreeOptions,
+): AnyCircuitElement[] {
+  if (!opts.subcircuit_id && !opts.source_group_id) return [...soup]
+
+  const idMap = new Map<string, AnyCircuitElement>()
+  for (const elm of soup) {
+    const idVal = (elm as any)[`${elm.type}_id`]
+    if (typeof idVal === "string") {
+      idMap.set(idVal, elm)
+    }
+  }
+
+  const adj = new Map<AnyCircuitElement, Set<AnyCircuitElement>>()
+  for (const elm of soup) {
+    const entries = Object.entries(elm as any)
+    for (const [key, val] of entries) {
+      if (key.endsWith("_id") && typeof val === "string") {
+        const other = idMap.get(val)
+        connect(adj, elm, other)
+      } else if (key.endsWith("_ids") && Array.isArray(val)) {
+        for (const v of val) {
+          if (typeof v === "string") {
+            const other = idMap.get(v)
+            connect(adj, elm, other)
+          }
+        }
+      }
+    }
+  }
+
+  const queue: AnyCircuitElement[] = []
+  const included = new Set<AnyCircuitElement>()
+
+  for (const elm of soup) {
+    if (
+      (opts.subcircuit_id &&
+        (elm as any).subcircuit_id === opts.subcircuit_id) ||
+      (opts.source_group_id &&
+        ((elm as any).source_group_id === opts.source_group_id ||
+          (Array.isArray((elm as any).member_source_group_ids) &&
+            (elm as any).member_source_group_ids.includes(
+              opts.source_group_id,
+            ))))
+    ) {
+      queue.push(elm)
+      included.add(elm)
+    }
+  }
+
+  while (queue.length > 0) {
+    const elm = queue.shift()!
+    const neighbors = adj.get(elm)
+    if (!neighbors) continue
+    for (const n of neighbors) {
+      if (!included.has(n)) {
+        included.add(n)
+        queue.push(n)
+      }
+    }
+  }
+
+  return soup.filter((e) => included.has(e))
+}

--- a/tests/subtree1.test.ts
+++ b/tests/subtree1.test.ts
@@ -1,0 +1,65 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { cju } from "../index"
+import { test, expect } from "bun:test"
+
+test("subtree by subcircuit", () => {
+  const soup: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "S1",
+      supplier_part_numbers: {},
+      ftype: "simple_resistor",
+      resistance: 1000,
+      subcircuit_id: "sub1",
+    },
+    {
+      type: "source_port",
+      name: "p1",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 1,
+      height: 1,
+      subcircuit_id: "sub1",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pt1",
+      pcb_component_id: "pc1",
+      route: [],
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc2",
+      name: "S2",
+      supplier_part_numbers: {},
+      ftype: "simple_resistor",
+      resistance: 2000,
+      subcircuit_id: "sub2",
+    },
+  ]
+
+  const st = cju(soup).subtree({ subcircuit_id: "sub1" })
+  const result = st.toArray()
+
+  expect(result.length).toBe(5)
+  expect(st.pcb_trace.get("pt1")).toBeTruthy()
+  expect(st.source_component.get("sc2")).toBeUndefined()
+})

--- a/tests/subtree2.test.ts
+++ b/tests/subtree2.test.ts
@@ -1,0 +1,50 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { cju } from "../index"
+import { test, expect } from "bun:test"
+
+test("subtree by source group", () => {
+  const soup: AnyCircuitElement[] = [
+    {
+      type: "source_group",
+      source_group_id: "g1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "st1",
+      source_group_id: "g1",
+      connected_source_port_ids: [],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "sct1",
+      source_trace_id: "st1",
+      junctions: [],
+      edges: [],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pt1",
+      source_trace_id: "st1",
+      route: [],
+    },
+    {
+      type: "source_group",
+      source_group_id: "g2",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "st2",
+      source_group_id: "g2",
+      connected_source_port_ids: [],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const st = cju(soup).subtree({ source_group_id: "g1" })
+  const result = st.toArray()
+
+  expect(result.length).toBe(4)
+  expect(st.schematic_trace.get("sct1")).toBeTruthy()
+  expect(st.source_trace.list().length).toBe(1)
+})


### PR DESCRIPTION
## Summary
- add `buildSubtree` helper
- expose `subtree` method on cju util
- test subtree behaviour for subcircuits and source groups

## Testing
- `npx @biomejs/biome lint .`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_683bab2e92c4832eb7dcfafc452978fb