### PR TITLE
Add moveSchematicElement utility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ export * from "./lib/readable-name-functions/get-readable-name-for-element"
 export * from "./lib/get-bounds-of-pcb-elements"
 export * from "./lib/find-bounds-and-center"
 export * from "./lib/get-primary-id"
+export * from "./lib/move-schematic-element"
 
 export { default as cju } from "./lib/cju"
 export { default as cjuIndexed } from "./lib/cju-indexed"

--- a/lib/move-schematic-element.ts
+++ b/lib/move-schematic-element.ts
@@ -1,0 +1,77 @@
+export const moveSchematicElement = (
+  schematic_element_id: string,
+  db: import("circuit-json").CircuitJson,
+  newPosition: { x: number; y: number },
+) => {
+  const element = db.find(
+    (e: any) =>
+      (e as any)[`${e.type}_id`] === schematic_element_id,
+  ) as any
+  if (!element) return null
+
+  const applyDelta = (dx: number, dy: number, obj: any) => {
+    if (obj.center) {
+      obj.center.x += dx
+      obj.center.y += dy
+    } else if (obj.position) {
+      obj.position.x += dx
+      obj.position.y += dy
+    } else if (typeof obj.x === "number" && typeof obj.y === "number") {
+      obj.x += dx
+      obj.y += dy
+    }
+  }
+
+  if (element.type === "schematic_component") {
+    const dx = newPosition.x - element.center.x
+    const dy = newPosition.y - element.center.y
+    applyDelta(dx, dy, element)
+    db.forEach((elm: any) => {
+      if (
+        elm.type === "schematic_port" &&
+        elm.schematic_component_id === element.schematic_component_id
+      ) {
+        applyDelta(dx, dy, elm)
+      }
+    })
+  } else if (element.type === "schematic_port") {
+    element.center = { ...newPosition }
+  } else if (element.type === "schematic_text") {
+    element.position = { ...newPosition }
+  } else if (element.type === "schematic_line") {
+    const cx = (element.x1 + element.x2) / 2
+    const cy = (element.y1 + element.y2) / 2
+    const dx = newPosition.x - cx
+    const dy = newPosition.y - cy
+    element.x1 += dx
+    element.x2 += dx
+    element.y1 += dy
+    element.y2 += dy
+  } else if (element.type === "schematic_box") {
+    const dx = newPosition.x - element.x
+    const dy = newPosition.y - element.y
+    element.x += dx
+    element.y += dy
+  } else if (element.type === "schematic_trace") {
+    const points = [
+      ...element.junctions,
+      ...element.edges.flatMap((e: any) => [e.from, e.to]),
+    ]
+    if (points.length) {
+      const cx =
+        points.reduce((s: number, p: any) => s + p.x, 0) / points.length
+      const cy =
+        points.reduce((s: number, p: any) => s + p.y, 0) / points.length
+      const dx = newPosition.x - cx
+      const dy = newPosition.y - cy
+      points.forEach((p: any) => {
+        p.x += dx
+        p.y += dy
+      })
+    }
+  } else {
+    applyDelta(newPosition.x - (element.center?.x ?? element.x ?? 0), newPosition.y - (element.center?.y ?? element.y ?? 0), element)
+  }
+
+  return element
+}

--- a/tests/move-schematic-element.test.ts
+++ b/tests/move-schematic-element.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { moveSchematicElement } from "../index"
+
+test("move schematic component also moves ports", () => {
+  const db: CircuitJson = [
+    {
+      type: "schematic_component",
+      schematic_component_id: "sc_0",
+      source_component_id: "src_0",
+      size: { width: 10, height: 10 },
+      center: { x: 0, y: 0 },
+    } as any,
+    {
+      type: "schematic_port",
+      schematic_port_id: "sp_0",
+      source_port_id: "sp0",
+      schematic_component_id: "sc_0",
+      center: { x: 1, y: 1 },
+    } as any,
+  ]
+
+  moveSchematicElement("sc_0", db, { x: 5, y: 5 })
+
+  const comp = db.find(e => (e as any).schematic_component_id === "sc_0" && e.type === "schematic_component") as any
+  const port = db.find(e => (e as any).schematic_port_id === "sp_0") as any
+  expect(comp.center).toEqual({ x: 5, y: 5 })
+  expect(port.center).toEqual({ x: 6, y: 6 })
+})
+
+test("move schematic port only", () => {
+  const db: CircuitJson = [
+    {
+      type: "schematic_port",
+      schematic_port_id: "sp_1",
+      source_port_id: "sp1",
+      center: { x: 0, y: 0 },
+    } as any,
+  ]
+  moveSchematicElement("sp_1", db, { x: 2, y: 3 })
+  const port = db[0] as any
+  expect(port.center).toEqual({ x: 2, y: 3 })
+})


### PR DESCRIPTION
## Summary
- add `moveSchematicElement` function to move schematic elements
- export `moveSchematicElement`
- test moving schematic components and ports

## Testing
- `bun test tests/move-schematic-element.test.ts`
- `bun run format` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860b9a22ccc832e94a90f65ba892c14