### PR TITLE
Add pcb component reposition utility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ export * from "./lib/get-bounds-of-pcb-elements"
 export * from "./lib/find-bounds-and-center"
 export * from "./lib/get-primary-id"
 export * from "./lib/subtree"
+export * from "./lib/reposition-pcb-component"
 
 export { default as cju } from "./lib/cju"
 export { default as cjuIndexed } from "./lib/cju-indexed"

--- a/lib/reposition-pcb-component.ts
+++ b/lib/reposition-pcb-component.ts
@@ -1,0 +1,66 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { transformPCBElements } from "./transform-soup-elements"
+import { translate } from "transformation-matrix"
+
+export const repositionPcbComponentTo = (
+  circuitJson: AnyCircuitElement[],
+  pcb_component_id: string,
+  newCenter: { x: number; y: number },
+) => {
+  const pcbComponent = circuitJson.find(
+    (e) =>
+      e.type === "pcb_component" &&
+      (e as any).pcb_component_id === pcb_component_id,
+  )
+  if (!pcbComponent) return
+
+  const currentCenter =
+    "center" in pcbComponent
+      ? (pcbComponent as any).center
+      : { x: (pcbComponent as any).x, y: (pcbComponent as any).y }
+
+  const dx = newCenter.x - currentCenter.x
+  const dy = newCenter.y - currentCenter.y
+
+  const portIds = circuitJson
+    .filter(
+      (e) =>
+        e.type === "pcb_port" &&
+        (e as any).pcb_component_id === pcb_component_id,
+    )
+    .map((e) => (e as any).pcb_port_id)
+
+  const elementsToMove = circuitJson.filter((elm) => {
+    if (elm === pcbComponent) return true
+    const anyElm: any = elm
+    if (anyElm.pcb_component_id === pcb_component_id) return true
+    if (
+      Array.isArray(anyElm.pcb_component_ids) &&
+      anyElm.pcb_component_ids.includes(pcb_component_id)
+    )
+      return true
+    if (anyElm.pcb_port_id && portIds.includes(anyElm.pcb_port_id)) return true
+    if (
+      Array.isArray(anyElm.pcb_port_ids) &&
+      anyElm.pcb_port_ids.some((id: string) => portIds.includes(id))
+    )
+      return true
+    if (anyElm.start_pcb_port_id && portIds.includes(anyElm.start_pcb_port_id))
+      return true
+    if (anyElm.end_pcb_port_id && portIds.includes(anyElm.end_pcb_port_id))
+      return true
+    if (
+      Array.isArray(anyElm.route) &&
+      anyElm.route.some(
+        (pt: any) =>
+          (pt.start_pcb_port_id && portIds.includes(pt.start_pcb_port_id)) ||
+          (pt.end_pcb_port_id && portIds.includes(pt.end_pcb_port_id)),
+      )
+    )
+      return true
+    return false
+  })
+
+  const matrix = translate(dx, dy)
+  transformPCBElements(elementsToMove, matrix)
+}

--- a/tests/reposition-pcb-component.test.ts
+++ b/tests/reposition-pcb-component.test.ts
@@ -1,0 +1,72 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { repositionPcbComponentTo } from "../lib/reposition-pcb-component"
+import { test, expect } from "bun:test"
+
+const makeSoup = (): AnyCircuitElement[] => [
+  {
+    type: "pcb_component",
+    pcb_component_id: "pc1",
+    source_component_id: "sc1",
+    center: { x: 0, y: 0 },
+    layer: "top",
+    rotation: 0,
+    width: 2,
+    height: 2,
+  } as any,
+  {
+    type: "pcb_port",
+    pcb_port_id: "pp1",
+    pcb_component_id: "pc1",
+    source_port_id: "sp1",
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  } as any,
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pad1",
+    pcb_port_id: "pp1",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    layer: "top",
+    shape: "rect",
+  } as any,
+  {
+    type: "pcb_trace",
+    pcb_trace_id: "t1",
+    route: [
+      {
+        x: 0,
+        y: 0,
+        width: 1,
+        layer: "top",
+        route_type: "wire",
+        start_pcb_port_id: "pp1",
+      },
+      { x: 5, y: 0, width: 1, layer: "top", route_type: "wire" },
+    ],
+  } as any,
+]
+
+test("repositionPcbComponentTo moves component and children", () => {
+  const soup = makeSoup()
+
+  repositionPcbComponentTo(soup, "pc1", { x: 10, y: 5 })
+
+  const comp = soup.find((e) => e.type === "pcb_component") as any
+  const port = soup.find((e) => e.type === "pcb_port") as any
+  const pad = soup.find((e) => e.type === "pcb_smtpad") as any
+  const trace = soup.find((e) => e.type === "pcb_trace") as any
+
+  expect(comp.center).toEqual({ x: 10, y: 5 })
+  expect(port.x).toBe(10)
+  expect(port.y).toBe(5)
+  expect(pad.x).toBe(10)
+  expect(pad.y).toBe(5)
+  expect(trace.route[0].x).toBe(10)
+  expect(trace.route[0].y).toBe(5)
+  expect(trace.route[1].x).toBe(15)
+  expect(trace.route[1].y).toBe(5)
+})


### PR DESCRIPTION
## Summary
- add `repositionPcbComponentTo` for moving pcb components and their children
- export the new helper
- test repositioning logic

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6880154c2d94832e9f9aeba5b9071515