### PR TITLE
Fix buildSubtree to include pcb_board

### DIFF
--- a/lib/subtree.ts
+++ b/lib/subtree.ts
@@ -40,6 +40,7 @@ export function buildSubtree(
   }
 
   const adj = new Map<AnyCircuitElement, Set<AnyCircuitElement>>()
+  const subcircuitBuckets = new Map<string, AnyCircuitElement[]>()
   for (const elm of soup) {
     const entries = Object.entries(elm as any)
     for (const [key, val] of entries) {
@@ -53,6 +54,20 @@ export function buildSubtree(
             connect(adj, elm, other)
           }
         }
+      }
+    }
+
+    const subId = (elm as any).subcircuit_id
+    if (typeof subId === "string") {
+      if (!subcircuitBuckets.has(subId)) subcircuitBuckets.set(subId, [])
+      subcircuitBuckets.get(subId)!.push(elm)
+    }
+  }
+
+  for (const bucket of subcircuitBuckets.values()) {
+    for (let i = 0; i < bucket.length; i++) {
+      for (let j = i + 1; j < bucket.length; j++) {
+        connect(adj, bucket[i], bucket[j])
       }
     }
   }

--- a/tests/subtree-board.test.ts
+++ b/tests/subtree-board.test.ts
@@ -1,0 +1,35 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { cju } from "../index"
+import { test, expect } from "bun:test"
+
+test("pcb_board included when using source group", () => {
+  const soup: AnyCircuitElement[] = [
+    {
+      type: "source_group",
+      source_group_id: "g1",
+      subcircuit_id: "sub1",
+    } as unknown as AnyCircuitElement,
+    {
+      type: "pcb_board",
+      pcb_board_id: "b1",
+      subcircuit_id: "sub1",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+    } as unknown as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      supplier_part_numbers: {},
+      source_group_id: "g1",
+    } as unknown as AnyCircuitElement,
+  ]
+
+  const st = cju(soup).subtree({ source_group_id: "g1" })
+
+  expect(st.pcb_board.list().length).toBe(1)
+  expect(st.pcb_board.get("b1")).toBeTruthy()
+})


### PR DESCRIPTION
## Summary
- ensure elements that share a `subcircuit_id` are connected when building a subtree
- add regression test verifying a board is included when filtering by source group

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68813db5b4dc8327aa2bea2ad143682d