### PR TITLE
Better empty group handling, put pcb_component as subelement of sourceComponent

### DIFF
--- a/lib/getCircuitJsonTree.ts
+++ b/lib/getCircuitJsonTree.ts
@@ -85,7 +85,14 @@ export const getCircuitJsonTree = (
               nodeType: "component",
               sourceComponent: elm,
               childNodes: [],
-              otherChildElements: [], // TODO
+              otherChildElements: [
+                ...circuitJson.filter(
+                  (e) =>
+                    e.type === "pcb_component" &&
+                    e.source_component_id ===
+                      (elm as SourceComponentBase).source_component_id,
+                ),
+              ], // TODO populate
             } as CircuitJsonTreeNode
           }),
       ],
@@ -99,7 +106,7 @@ export const getCircuitJsonTree = (
     console.warn("No groups were processed, returning tree without sourceGroup")
     return {
       nodeType: "group",
-      childNodes: [],
+      childNodes: [], // TODO populate
       otherChildElements: circuitJson,
     }
   }

--- a/lib/getCircuitJsonTree.ts
+++ b/lib/getCircuitJsonTree.ts
@@ -96,9 +96,12 @@ export const getCircuitJsonTree = (
   }
 
   if (!lastGroupId) {
-    throw new Error(
-      "Could not compute circuit tree because no groups were processed",
-    )
+    console.warn("No groups were processed, returning tree without sourceGroup")
+    return {
+      nodeType: "group",
+      childNodes: [],
+      otherChildElements: circuitJson,
+    }
   }
 
   return groupNodes.get(opts?.source_group_id ?? lastGroupId)!


### PR DESCRIPTION
- **improve handling for groupless case**
- **better empty group handling**
