### PR TITLE
Add silkscreen path transform support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,5 +14,10 @@ export * from "./lib/reposition-pcb-component"
 export * from "./lib/getCircuitJsonTree"
 export * from "./lib/getStringFromCircuitJsonTree"
 
+export {
+  transformPCBElement as transformPcbElement,
+  transformPCBElements as transformPcbElements,
+} from "./lib/transform-soup-elements"
+
 export { default as cju } from "./lib/cju"
 export { default as cjuIndexed } from "./lib/cju-indexed"

--- a/lib/convert-abbreviation-to-soup-element-type.ts
+++ b/lib/convert-abbreviation-to-soup-element-type.ts
@@ -6,6 +6,8 @@ export const convertAbbrToType = (abbr: string): string => {
       return "source_net"
     case "power":
       return "simple_power_source"
+    case "silkscreenpath":
+      return "pcb_silkscreen_path"
   }
   return abbr
 }

--- a/tests/transform-pcb-elements.test.ts
+++ b/tests/transform-pcb-elements.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { translate } from "transformation-matrix"
+import type { AnyCircuitElement } from "circuit-json"
+import { transformPCBElements } from "../lib/transform-soup-elements"
+
+
+test("transformPCBElements moves pcb_silkscreen_path route", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_silkscreen_path",
+      pcb_silkscreen_path_id: "sp1",
+      pcb_component_id: "pc1",
+      layer: "top",
+      route: [
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+      ],
+      stroke_width: 0.2,
+    } as any,
+  ]
+
+  transformPCBElements(elms, translate(2, 3))
+
+  const path = elms[0] as any
+  expect(path.route[0]).toEqual({ x: 2, y: 3 })
+  expect(path.route[1]).toEqual({ x: 3, y: 4 })
+})


### PR DESCRIPTION
## Summary
- map `silkscreenpath` to `pcb_silkscreen_path`
- alias transformPCBElements/transformPCBElement to camelCase exports
- test pcb_silkscreen_path with transformPCBElements

## Testing
- `bun test tests/transform-pcb-elements.test.ts`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6885c8b9e73c832e89638217fd7a3add