### PR TITLE
Test cutout rotation with circuit json

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -69,6 +69,13 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
   } else if (elm.type === "pcb_keepout" || elm.type === "pcb_board") {
     // TODO adjust size/rotation
     elm.center = applyToPoint(matrix, elm.center)
+  } else if (elm.type === "pcb_cutout") {
+    // Transform center position
+    elm.center = applyToPoint(matrix, elm.center)
+    // Handle width/height rotation for rectangular cutouts
+    if (flipPadWidthHeight && elm.shape === "rect") {
+      ;[elm.width, elm.height] = [elm.height, elm.width]
+    }
   } else if (
     elm.type === "pcb_silkscreen_text" ||
     elm.type === "pcb_fabrication_note_text"


### PR DESCRIPTION
Add rotation handling for `pcb_cutout` elements in `transformPcbElements` to correctly swap width/height on 90-degree rotations.

---

[Open in Web](https://cursor.com/agents?id=bc-72923c4e-23af-43d4-84e9-04998b092797) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-72923c4e-23af-43d4-84e9-04998b092797) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)