### PR TITLE
Test cutout rotation with circuit json

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -69,6 +69,14 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
   } else if (elm.type === "pcb_keepout" || elm.type === "pcb_board") {
     // TODO adjust size/rotation
     elm.center = applyToPoint(matrix, elm.center)
+  } else if (elm.type === "pcb_cutout") {
+    // Transform the position of the cutout
+    const { x, y } = applyToPoint(matrix, {
+      x: elm.x,
+      y: elm.y,
+    })
+    elm.x = x
+    elm.y = y
   } else if (
     elm.type === "pcb_silkscreen_text" ||
     elm.type === "pcb_fabrication_note_text"
@@ -128,6 +136,9 @@ export const transformPCBElements = (
   if (flipPadWidthHeight) {
     transformedElms = transformedElms.map((elm) => {
       if (elm.type === "pcb_smtpad" && elm.shape === "rect") {
+        ;[elm.width, elm.height] = [elm.height, elm.width]
+      }
+      if (elm.type === "pcb_cutout" && elm.shape === "rect") {
         ;[elm.width, elm.height] = [elm.height, elm.width]
       }
       return elm

--- a/tests/transform-pcb-cutout.test.ts
+++ b/tests/transform-pcb-cutout.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import { rotateDEG } from "transformation-matrix"
+import type { AnyCircuitElement } from "circuit-json"
+import { transformPCBElements } from "../lib/transform-soup-elements"
+
+test("transformPCBElements rotates pcb_cutout and swaps width/height for 90 degree rotation", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "cutout1",
+      shape: "rect",
+      x: 10,
+      y: 5,
+      width: 20,
+      height: 10,
+    } as any,
+  ]
+
+  const rotated = transformPCBElements(elms, rotateDEG(90))
+
+  const cutout = rotated[0] as any
+  
+  // Position should be rotated
+  expect(cutout.x).toBeCloseTo(-5)
+  expect(cutout.y).toBeCloseTo(10)
+  
+  // Width and height should be swapped for 90 degree rotation
+  expect(cutout.width).toBe(10)
+  expect(cutout.height).toBe(20)
+})
+
+test("transformPCBElements does not swap width/height for 180 degree rotation", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "cutout1",
+      shape: "rect",
+      x: 10,
+      y: 5,
+      width: 20,
+      height: 10,
+    } as any,
+  ]
+
+  const rotated = transformPCBElements(elms, rotateDEG(180))
+
+  const cutout = rotated[0] as any
+  
+  // Position should be rotated
+  expect(cutout.x).toBeCloseTo(-10)
+  expect(cutout.y).toBeCloseTo(-5)
+  
+  // Width and height should NOT be swapped for 180 degree rotation
+  expect(cutout.width).toBe(20)
+  expect(cutout.height).toBe(10)
+})
+
+test("transformPCBElements handles pcb_cutout without shape property", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "cutout1",
+      x: 10,
+      y: 5,
+      width: 20,
+      height: 10,
+    } as any,
+  ]
+
+  const rotated = transformPCBElements(elms, rotateDEG(90))
+
+  const cutout = rotated[0] as any
+  
+  // Position should be rotated
+  expect(cutout.x).toBeCloseTo(-5)
+  expect(cutout.y).toBeCloseTo(10)
+  
+  // Width and height should NOT be swapped if shape is not explicitly "rect"
+  expect(cutout.width).toBe(20)
+  expect(cutout.height).toBe(10)
+})


### PR DESCRIPTION
Add `pcb_cutout` transformation to `transformPCBElements` to ensure cutouts rotate correctly with the PCB.

Previously, `pcb_cutout` elements were not handled by `transformPCBElements`, causing them to remain static while other PCB elements rotated. This change ensures their position is transformed and their width/height are swapped for 90/270 degree rotations, aligning with how `pcb_smtpad` elements are handled.

---

[Open in Web](https://cursor.com/agents?id=bc-ff7ca0df-45ec-4825-858b-246ca3de3aca) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ff7ca0df-45ec-4825-858b-246ca3de3aca) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)